### PR TITLE
Modify test.php file to delete './'

### DIFF
--- a/List/countCharsAfterN/php/test.php
+++ b/List/countCharsAfterN/php/test.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once './solution.php';
+require_once 'solution.php';
 
 var_dump(countCharactersAfterN(["the wood","pecked peckers","at the inn","tomorrowland"])) . PHP_EOL;
 var_dump(countCharactersAfterN(["he","fumbled","in","the","darkness","looking","for","the","light","switch"])) . PHP_EOL;


### PR DESCRIPTION
test.phpの修正
・ファイル読み込みエラーの解消するため、"./" を削除