### PR TITLE
Fix unclosed code block in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Algorithm-Solutions/
 │            ├── javascript/ # JavaScriptの解答
 │            ├── php/       # PHPの解答
 │            ├── java/      # Javaの解答
-
+```
 
 ## 学習記録の管理
 日々の学習記録は以下にまとめています。


### PR DESCRIPTION
## 概要
README.md 内のコードブロック（```）の閉じ忘れがあったため修正しました

## 変更内容
- README.md のコードブロックを正しく閉じるよう修正

## 補足
- 表示崩れが発生していた箇所をVS Code上で確認済みです