### PR TITLE
Create reusable Item and Stack classes with export for modular use in JavaScript

### DIFF
--- a/Stack/Common/js/Item.js
+++ b/Stack/Common/js/Item.js
@@ -1,0 +1,6 @@
+export class Item {
+    constructor(data){
+        this.data = data;
+        this.next = null;
+    }
+}

--- a/Stack/Common/js/Stack.js
+++ b/Stack/Common/js/Stack.js
@@ -1,0 +1,28 @@
+import { Item } from './Item.js';
+
+class Stack {
+    constructor(){
+        this.head = null;
+    }
+
+    push(data){
+        const temp = this.head;
+        this.head = new Item(data);
+        this.head.next = temp;
+    }
+
+    pop(){
+        if(this.head === null) return null;
+
+        const temp = this.head;
+        this.head = this.head.next;
+
+        return temp.data;
+    }
+
+    peek(){
+        if(this.head === null) return null;
+
+        return this.head.data;
+    }
+}

--- a/Stack/Common/js/Stack.js
+++ b/Stack/Common/js/Stack.js
@@ -1,6 +1,6 @@
 import { Item } from './Item.js';
 
-class Stack {
+export class Stack {
     constructor(){
         this.head = null;
     }


### PR DESCRIPTION
## 概要
ItemクラスとStackクラスを共通で使えるように作成しました

## 内容
- Itemクラスはリンクリストのノードとして機能します
- StackクラスはItemクラスを使い、push/pop/peekメソッドを実装したスタック構造です
- 両クラスにexportを付け、他のモジュールからインポートして再利用可能にしました

## 補足
この実装により、複数の場所で共通のデータ構造としてスタックを利用でき、コードの再利用性が向上します