### PR TITLE
Merge Node and Deque classes in PHP into main

### DIFF
--- a/Deque/src/php/Deque/Deque.php
+++ b/Deque/src/php/Deque/Deque.php
@@ -1,0 +1,99 @@
+<?php 
+
+require_once './Node.php';
+
+class Deque
+{
+    public ?Node $head;
+    public ?Node $tail;
+
+    public function __construct()
+    {
+        $this->head = null;
+        $this->tail = null;
+    }
+
+    public function peekFront(): ?int
+    {
+        if($this->head === null){
+            return null;
+        }
+
+        return $this->head->data;
+    }
+
+    public function peekBack(): ?int
+    {
+        if($this->tail === null){
+            return null;
+        }
+
+        return $this->tail->data;
+    }
+
+    public function enqueueFront(int $data): void
+    {
+        $newHead = new Node($data);
+
+        if($this->head === null){
+            $this->head = $newHead;
+            $this->tail = $newHead;
+        } else {
+            $newHead->prev = null;
+            $newHead->next = $this->head;
+            $this->head->prev = $newHead;
+            $this->head = $newHead;
+        }
+    }
+
+    public function enqueueBack(int $data): void
+    {
+        $newTail = new Node($data);
+
+        if($this->tail === null){
+            $this->tail = $newTail;
+            $this->head = $newTail;
+        } else {
+            $newTail->next = null;
+            $newTail->prev = $this->tail;
+            $this->tail->next = $newTail;
+            $this->tail = $newTail;
+        }
+    }
+
+    public function dequeueFront(): ?int
+    {
+        if($this->head === null){
+            return null;
+        }
+
+        $temp = $this->head;
+        $this->head = $this->head->next;
+
+        if($this->head === null){
+            $this->tail = null;
+        } else {
+            $this->head->prev = null;
+        }
+
+        return $temp->data;
+    }
+
+    public function dequeueBack(): ?int
+    {
+        if($this->tail === null){
+            return null;
+        }
+
+        $temp = $this->tail;
+        $this->tail = $this->tail->prev;
+
+        if($this->tail === null){
+            $this->head = null;
+        } else {
+            $this->tail->next = null;
+        }
+
+        return $temp->data;
+    }
+}

--- a/Deque/src/php/Deque/Node.php
+++ b/Deque/src/php/Deque/Node.php
@@ -2,11 +2,11 @@
 
 class Node 
 {
-    public $data;
-    public $prev;
-    public $next;
+    public int $data;
+    public ?Node $prev;
+    public ?Node $next;
 
-    public function __construct($data)
+    public function __construct(int $data)
     {
         $this->data = $data;
         $this->prev = null;

--- a/Deque/src/php/Deque/Node.php
+++ b/Deque/src/php/Deque/Node.php
@@ -1,0 +1,15 @@
+<?php
+
+class Node 
+{
+    public $data;
+    public $prev;
+    public $next;
+
+    public function __construct($data)
+    {
+        $this->data = $data;
+        $this->prev = null;
+        $this->next = null;
+    }
+}


### PR DESCRIPTION
## 概要
双方向リンクリストを用いたデータ構造として、NodeクラスとDequeクラスをPHPで実装しました

## データ構造
- Dequeクラスは双方向リンクリスト（前後の要素を双方向にたどれるリスト）を使って実装しています
- Nodeクラスは各要素の前後のノードへのリンク（prev, next）を管理します

## メソッド
- peekFront(): 先頭ノードの値を取得（削除はしない）
- peekBack(): 末尾ノードの値を取得（削除はしない）
- enqueueFront(int $data): 先頭に新しいノードを追加
- enqueueBack(int $data): 末尾に新しいノードを追加
- dequeueFront(): 先頭のノードを削除し、その値を返す
- dequeueBack(): 末尾のノードを削除し、その値を返す