### PR TITLE
fix: change relative path to absolute path using __DIR__

### DIFF
--- a/Deque/src/php/Deque/Deque.php
+++ b/Deque/src/php/Deque/Deque.php
@@ -1,6 +1,6 @@
 <?php 
 
-require_once './Node.php';
+require_once __DIR__ . '/Node.php';
 
 class Deque
 {


### PR DESCRIPTION
## 概要
相対パスでのファイル読み込みを絶対パス（__DIR__使用）に変更しました

## 内容
- Deque.php 内で Node.php を読み込むパスを、相対パスから __DIR__ を使った絶対パスに変更
- Deque クラスを使って関数を実装した際、相対パスのままだと読み込みエラーが発生したため修正しました