### PR TITLE
refactor: update test cases to use binarySubTreeToArray for array output and encode with json_encode

### DIFF
--- a/binary-tree/problems/07_successor/php/src/successor.php
+++ b/binary-tree/problems/07_successor/php/src/successor.php
@@ -5,53 +5,51 @@ require_once __DIR__ . '/../../../../src/php/BinaryTree.php';
 function successor(?BinaryTree $root, int $key): ?BinaryTree
 {
     $targetNode = findNode($root, $key);
-    if($targetNode == null) return null;
-    if($targetNode->right !== null) return minimumNode($root);
-
+    if ($targetNode === null) return null;
+    if ($targetNode->right !== null) {
+        return minimumNode($targetNode->right);
+    }
+    
     $successor = null;
-    $currentNode = $root;
-
-    while($currentNode !== null){
-        if($targetNode->data === $currentNode->data){
-            return $successor;
-        }
-
-        if($targetNode->data < $currentNode->data){
-            $successor = $currentNode;
-            $currentNode = $currentNode->left;
+    $current = $root;
+    
+    while ($current !== null) {
+        if ($targetNode->data < $current->data) {
+            $successor = $current;
+            $current = $current->left;
+        } elseif ($targetNode->data > $current->data) {
+            $current = $current->right;
         } else {
-            $currentNode = $currentNode->right;
+            break;
         }
     }
-
+    
     return $successor;
 }
 
 function findNode(?BinaryTree $root, int $key): ?BinaryTree
 {
-    $currentNode = $root;
-
-    while($currentNode !== null){
-        if($currentNode->data === $key){
-            return $currentNode;
+    $current = $root;
+    
+    while ($current !== null) {
+        if ($key === $current->data) {
+            return $current;
         }
-        if($currentNode->data < $key){
-            $currentNode = $currentNode->left;
+        if ($key < $current->data) {
+            $current = $current->left;
         } else {
-            $currentNode = $currentNode->right;
+            $current = $current->right;
         }
     }
-
-    return $currentNode;
+    
+    return null;
 }
 
-function minimumNode(?BinaryTree $root): BinaryTree
+function minimumNode(BinaryTree $node): BinaryTree
 {
-    $currentNode = $root;
-    
-    while($currentNode !== null && $currentNode->left !== null){
-        $currentNode = $currentNode->left;
+    $current = $node;
+    while ($current->left !== null) {
+        $current = $current->left;
     }
-
-    return $currentNode;
+    return $current;
 }

--- a/binary-tree/problems/07_successor/php/tests/successorTest.php
+++ b/binary-tree/problems/07_successor/php/tests/successorTest.php
@@ -1,44 +1,45 @@
 <?php 
 
 require_once __DIR__ . '/../../../../src/php/toBinaryTree.php';
+require_once __DIR__ . '/../../../../src/php/binarySubtreeToArray.php';
 require_once __DIR__ . '/../src/successor.php';
 
 // 1. 
 $root1 = toBinaryTree([0,-10,5,null,-3,null,9]);
-echo successor($root1, 5);
+echo json_encode(binarySubtreeToArray(successor($root1, 5))) . PHP_EOL;
 
 // 2.
 $root2 = toBinaryTree([5,3,6,2,4,null,7]);
-echo successor($root2, 5);
+echo json_encode(binarySubtreeToArray(successor($root2, 5))) . PHP_EOL;
 
 // 3.
 $root3 = toBinaryTree([10,6,12,4,8,null,null,2]);
-echo successor($root3, 12);
+echo json_encode(binarySubtreeToArray(successor($root3, 12))) . PHP_EOL;
 
 // 4.
 $root4 = toBinaryTree([10,6,12,4,8,null,null,2]);
-echo successor($root2, 2);
+echo json_encode(binarySubtreeToArray(successor($root4, 2))) . PHP_EOL;
 
 // 5.
 $root5 = toBinaryTree([5,4,null]);
-echo successor($root5, 5);
+echo json_encode(binarySubtreeToArray(successor($root5, 5))) . PHP_EOL;
 
 // 6.
 $root6 = toBinaryTree([-2,-17,8,-18,-11,3,19,null,null,null,-4,null,null,null,25]);
-echo successor($root6, 8);
+echo json_encode(binarySubtreeToArray(successor($root6, 8))) . PHP_EOL;
 
 // 7.
 $root7 = toBinaryTree([3,-3,13,-7,1,6,18,-10,-4,0,2,5,8,15,19]);
-echo successor($root7, 6);
+echo json_encode(binarySubtreeToArray(successor($root7, 6))) . PHP_EOL;
 
 // 8.
 $root8 = toBinaryTree([3,-3,13,-7,1,6,18,-10,-4,0,2,5,8,15,19]);
-echo successor($root8, 3);
+echo json_encode(binarySubtreeToArray(successor($root8, 3))) . PHP_EOL;
 
 // 9.
 $root9 = toBinaryTree([1,-5,15,-9,-4,10,17,null,-6,null,0,null,14,16,19]);
-echo successor($root9, 10);
+echo json_encode(binarySubtreeToArray(successor($root9, 10))) . PHP_EOL;
 
 // 10.
 $root10 = toBinaryTree([0,-10,5,null,-3,null,9]);
-echo successor($root10, -3);
+echo json_encode(binarySubtreeToArray(successor($root10, -3))) . PHP_EOL;


### PR DESCRIPTION
テストケースで以下の関数を使い、配列出力から文字列出力に変更しました
- `binarySubtreeToArrray`関数
- `json_encode`

`successor`のロジックを変更しました