### PR TITLE
Implement sortedArrToBST and sortedArrToBSTHelper function in JavaScript 

### DIFF
--- a/binary-tree/problems/08_sortedArrToBST/README.md
+++ b/binary-tree/problems/08_sortedArrToBST/README.md
@@ -48,12 +48,66 @@
 
 ## 悩んだ箇所
 
+- 再帰処理を実装すること
+過去の問題を見返して、関数の呼び出しと戻りを紙に書いて、現在なんの処理をしているのかを整理して進めたことでコードに落とし込んだ
+
 
 ## 直面したエラーと解決策
 
+- 葉ノード以下に不要な`null`がついていたこと
+
+【原因】`binarySubtreeToArray`関数のロジックに一部誤りがあったこと  
+
+【解決策】whileループ内の処理ロジックを変更  
+
+```js
+// 変更前
+    while(queue.length > 0){
+        const current = queue.shift();
+        result.push(current.data);
+
+        if(current.left !== null){
+            queue.push(current.left);
+        } else {
+            result.push(null);
+        }
+        
+        if(current.right !== null){
+            queue.push(current.right);
+        } else {
+            result.push(null);
+        }
+    }
+
+// 変更後
+    while(queue.length > 0){
+        const current = queue.shift();
+
+        if(current === null){
+            result.push(null);
+            continue;
+        }
+
+        result.push(current.data);
+        queue.push(current.left);
+        queue.push(current.right);
+    }
+```
 
 ## 気づき
+
+- 過去に実装した二分木を配列として表示する`binarySubtreeToArray`関数のロジックを見返したときに、可読性が悪く、不要な記述がたくさんあることに気づいた
+今回、使用している中でロジックの不備に気づいたことがきっかけとなった
+- 定期的に過去に書いたロジックも見返すことで、どう変更すると可読性が良くなるのか、保守性はいいのか、といった観点をもって変更することができるとわかった
+- 何を繰り返すとどんな結果が期待できるか、という分割統治法と再帰の特性を生かして実装するときに必要な視点を整理することができた
 
 
 ## フィードバック・改善点
 
+- リストの中身がないときの書き方（任意）
+
+```js
+if (numberList.length === 0) return null;
+// ↓ より短く
+if (!numberList.length) return null;
+```

--- a/binary-tree/problems/08_sortedArrToBST/js/src/sortedArrToBST.js
+++ b/binary-tree/problems/08_sortedArrToBST/js/src/sortedArrToBST.js
@@ -1,0 +1,23 @@
+const BinaryTree = require('../../../../src/js/BinaryTree');
+
+function sortedArrToBST(numberList){
+    let len = numberList.length;
+
+    if(len === 0) return null;
+    else return sortedArrToBSTHelper(numberList, 0, len-1);
+}
+
+function sortedArrToBSTHelper(arr, start, end){
+    // ベースケース: 部分配列に要素が1つだけのとき、葉ノードを作成
+    if(start === end) return new BinaryTree(arr[start]);
+
+    // 再帰ケース: 部分配列を左右に分割して左右の子ノードを構築
+    let mid = Math.floor((start + end) / 2);
+    
+    let left = start < mid ? sortedArrToBSTHelper(arr, start, mid-1) : null;
+    let right = mid < end ? sortedArrToBSTHelper(arr, mid+1, end) : null;
+
+    return new BinaryTree(arr[mid], left, right);
+}
+
+module.exports = sortedArrToBST;

--- a/binary-tree/problems/08_sortedArrToBST/js/tests/sortedArrToBSTTest.js
+++ b/binary-tree/problems/08_sortedArrToBST/js/tests/sortedArrToBSTTest.js
@@ -1,0 +1,17 @@
+const sortedArrToBST = require('../src/sortedArrToBST.js');
+const binarySubtreeToArray = require('../../../../src/js/binarySubtreeToArray.js');
+
+// 1.
+console.log(binarySubtreeToArray(sortedArrToBST([1,2,3])));
+
+// 2.
+console.log(binarySubtreeToArray(sortedArrToBST([1,2,3,5,6,9,10])));
+
+// 3.
+console.log(binarySubtreeToArray(sortedArrToBST([-1,0,3,10,13,19,22])));
+
+// 4.
+console.log(binarySubtreeToArray(sortedArrToBST([1,3,4,5,8])));
+
+// 5.
+console.log(binarySubtreeToArray(sortedArrToBST([1,4,6,10,11,14,15,20,22,25,50,61,68,72])));

--- a/binary-tree/src/js/binarySubtreeToArray.js
+++ b/binary-tree/src/js/binarySubtreeToArray.js
@@ -1,26 +1,20 @@
 function binarySubtreeToArray(root){
-    if(root === null){
-        return [];
-    }
+    if(root === null) return [];
 
     const result = [];
     const queue = [root];
 
     while(queue.length > 0){
         const current = queue.shift();
-        result.push(current.data);
 
-        if(current.left !== null){
-            queue.push(current.left);
-        } else {
+        if(current === null){
             result.push(null);
+            continue;
         }
-        
-        if(current.right !== null){
-            queue.push(current.right);
-        } else {
-            result.push(null);
-        }
+
+        result.push(current.data);
+        queue.push(current.left);
+        queue.push(current.right);
     }
 
     while(result.length > 0 && result[result.length - 1] === null){

--- a/progress/2025-07.md
+++ b/progress/2025-07.md
@@ -31,3 +31,4 @@
 | 07-27 | ニ分木 | successor | PHP | [Code](../binary-tree/problems/07_successor/php/src/successorTest.php)| `findNode`関数の修正 |
 | 07-28 | ニ分木 | successor | PHP | [Code](../binary-tree/problems/07_successor/php/src/successor.php)| リイファクタリング・README追記 |
 | 07-29 | ニ分木 | sortedArrToBST | JavaScript | [Code](../binary-tree/problems/08_sortedArrToBST)| 問題のセットアップ・問題/仮説をREADMEに追記 |
+| 07-30 | ニ分木 | sortedArrToBST | JavaScript | [Code](../binary-tree/problems/08_sortedArrToBST)| 関数の実装／リファクタリング・検証結果の追記 |


### PR DESCRIPTION
## 概要
`sortedArrToBST`関数を補助関数`sortedArrToBSTHelper`を使って実装しました

## 補助関数を使用した目的
分割統治法を使って実装するためには配列の最初と最後のインデックスが引数として追加で必要であったため

## 内容
- 補助関数`sortedArrToBSTHelper`を使い、`sortedArrToBST`関数を実装
- テストケースの実装
- `binarySubtreeToArray`関数のループロジックを変更
→ 葉ノードの子が存在しない場合に `null` が冗長に追加されていたため、キューに `null` を入れて明示的に処理し、不要な `null` を除外するように修正
- READMEに検証結果と気づきを追加
- 学習ログの追加

## 補足
`sortedArrToBSTTest.js`にテストケースを記述し、正しく出力されることを確認済み
